### PR TITLE
Added explicit comment not for prod in sample manifest

### DIFF
--- a/k8s/dev/dev-minio-manifest.yaml
+++ b/k8s/dev/dev-minio-manifest.yaml
@@ -12,8 +12,8 @@ metadata:
     heritage: Tiller
 type: Opaque
 data:
-  accesskey: "QUtJQUlPU0ZPRE5ON0VYQU1QTEU="
-  secretkey: "d0phbHJYVXRuRkVNSS9LN01ERU5HL2JQeFJmaUNZRVhBTVBMRUtFWQ=="
+  accesskey: "QUtJQUlPU0ZPRE5ON0VYQU1QTEU=" # Example credential, not for production
+  secretkey: "d0phbHJYVXRuRkVNSS9LN01ERU5HL2JQeFJmaUNZRVhBTVBMRUtFWQ==" # Example credential, not for production
 
 ---
 # Source: minio/templates/configmap.yaml

--- a/k8s/dev/dev-openldap-manifest.yaml
+++ b/k8s/dev/dev-openldap-manifest.yaml
@@ -12,8 +12,8 @@ metadata:
     heritage: Tiller
 type: Opaque
 data:
-  LDAP_ADMIN_PASSWORD: "cGlvbmV4YW1wbGVwYXNzd29yZA=="
-  LDAP_CONFIG_PASSWORD: "WjFlUE13YlNXUHFGOWwwaDl2SlpSblZJdlRUbmd6cXM="
+  LDAP_ADMIN_PASSWORD: "cGlvbmV4YW1wbGVwYXNzd29yZA==" # Example credential, not for production
+  LDAP_CONFIG_PASSWORD: "WjFlUE13YlNXUHFGOWwwaDl2SlpSblZJdlRUbmd6cXM=" # Example credential, not for production
 
 
 ---


### PR DESCRIPTION
Purpose: Added comments in the sample manifest to clarify that they're using example credentials. These credentials are *NOT* for production systems.